### PR TITLE
recover imports in AttributesInitialization

### DIFF
--- a/supported-frameworks/jdi-x.x.x/src/main/java/org/websync/jdi/AttributesInitialization.java
+++ b/supported-frameworks/jdi-x.x.x/src/main/java/org/websync/jdi/AttributesInitialization.java
@@ -1,8 +1,9 @@
 package org.websync.jdi;
 
-
 import com.epam.jdi.light.elements.common.Label;
 import com.epam.jdi.light.elements.composite.WebPage;
+import com.epam.jdi.light.elements.pageobjects.annotations.*;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.*;
 
 public class AttributesInitialization extends WebPage {
 


### PR DESCRIPTION
recover removed imports
import com.epam.jdi.light.elements.pageobjects.annotations.*;
import com.epam.jdi.light.elements.pageobjects.annotations.locators.*;
in AttributesInitialization class