### PR TITLE
fix AnalyzerTestHeavy.java

### DIFF
--- a/plugin/src/test/java/org/websync/AnalyzerTestHeavy.java
+++ b/plugin/src/test/java/org/websync/AnalyzerTestHeavy.java
@@ -16,12 +16,10 @@ import java.nio.file.Paths;
 public class AnalyzerTestHeavy extends ImportFromSourcesTestCase {
 
     //TODO: exclude hadcoded local path
-    private String srcPath = "C:\\Users\\Vitalii_Balitckii\\IdeaProjects\\jdi-light-testng-template\\";
     private Path path = Paths.get(srcPath);
     private File file = new File(srcPath);
 
     public void test0() {
-        Project project = null;
         try {
             myProject = ProjectManager.getInstance().loadAndOpenProject(srcPath);
         } catch (IOException e) {


### PR DESCRIPTION
remove local variable
 Project project = null;
reason: nunused even in class where declared

remove
private String srcPath
Reason: hard code of local path